### PR TITLE
Timeout exc

### DIFF
--- a/src/firedamp/core.clj
+++ b/src/firedamp/core.clj
@@ -26,7 +26,7 @@
 
 (def bad-fetch-msg "problem fetching")
 
-(def timeout-after (mt/seconds 5))
+(def timeout-after (mt/seconds 10))
 
 (def state (atom {:alarm-state ::good
                   :last-update (time/now)}))

--- a/test/firedamp/core_test.clj
+++ b/test/firedamp/core_test.clj
@@ -102,8 +102,6 @@
                 :github core/github-good}
                @(core/get-parse-statuses!))))))
   (testing "returns data when fetching timed out"
-    ;; shouldn't this throw?
-    ;; you could use a fake clock
     (let [calls (atom [])
           fake-get (fn [url]
                      (mt/in

--- a/test/firedamp/core_test.clj
+++ b/test/firedamp/core_test.clj
@@ -67,7 +67,7 @@
           (let [result (core/fetch-json-status! core/github)]
             (mt/advance clock (mt/seconds core/timeout-after))
             (is (thrown-with-msg? TimeoutException
-                                  #"timed out after 5000.0 milliseconds" @result))
+                                  #"timed out after 10000.0 milliseconds" @result))
             (is (= [core/github] @hits))))))))
 
 (deftest get-next-state


### PR DESCRIPTION
Use md/timeout! to cap the amount of time requests to fetch statuses can take at `firedamp.core/timeout-after` seconds.
